### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,3 +5,9 @@ services:
     command: ["gcloud", "beta", "emulators", "pubsub", "start", "--host-port=0.0.0.0:8085", "--project=test"]
     ports:
       - "8085:8085"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8085/v1/projects/nonsense/schemas" , "|", "exit", "1"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8085:8085"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8085/v1/projects/nonsense/schemas" , "|", "exit", "1"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8085/v1/projects/nonsense/schemas" , "||", "exit", "1"]
       interval: 1m30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Sometimes the emulator hasn't started, or stops working (or never starts up!), so adding a healthcheck is helpful.

Test it locally by running emulator in the background: 
```
gcloud beta emulators pubsub start &
curl --fail http://127.0.0.1:8085/v1/projects/nonsense/schemas
```
returns:
```
{
}
```
and `$?` is `0`
so you can use in your Dockerfile:
```
HEALTHCHECK CMD curl --fail http://127.0.0.1:8085/v1/projects/nonsense/schemas || exit 1
```